### PR TITLE
Fix for excessive reloads of modified items in TLIndexPathUpdates

### DIFF
--- a/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
+++ b/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
@@ -39,7 +39,7 @@
     if (self = [super init]) {
         
         _oldDataModel = oldDataModel;
-        _updatedDataModel = updatedDataModel;performBatchUpdates
+        _updatedDataModel = updatedDataModel;
         _updateModifiedItems = YES;
         
         NSMutableArray *insertedSectionNames = [[NSMutableArray alloc] init];


### PR DESCRIPTION
Seems to be a bug because it's not needed to reload the same items again and again every loop iteration
