### PR TITLE
Invoke completion block when updating from nil dataModel

### DIFF
--- a/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
+++ b/TLIndexPathTools/Data Model/TLIndexPathUpdates.m
@@ -151,6 +151,9 @@
 {
     if (!self.oldDataModel) {
         [tableView reloadData];
+        if (completion) {
+            completion(YES);
+        }
         return;
     }
 


### PR DESCRIPTION
I think completion block should be invoked anyway if it was set. Even if it's first time dataModel updated
