### PR TITLE
Fixed UB warning in -hash

### DIFF
--- a/TLIndexPathTools/Data Model/TLIndexPathItem.m
+++ b/TLIndexPathTools/Data Model/TLIndexPathItem.m
@@ -49,7 +49,7 @@
 
 - (NSUInteger)hash
 {
-    NSInteger hash = 0;
+    NSUInteger hash = 0;
     hash += 31 * hash + [self.identifier hash];
     hash += 31 * hash + [self.sectionName hash];
     hash += 31 * hash + [self.cellIdentifier hash];


### PR DESCRIPTION
-hash should only use unsigned integer